### PR TITLE
add option to add MappedDiagnosticContext to gelf-output

### DIFF
--- a/src/Axoom.Extensions.Logging.Console/ConsoleLoggerOptions.cs
+++ b/src/Axoom.Extensions.Logging.Console/ConsoleLoggerOptions.cs
@@ -16,8 +16,9 @@ namespace Axoom.Extensions.Logging.Console
             Format = ReadLogFormat(configuration);
             Async = ReadAsync(configuration);
         }
-        
+
         public LogFormat Format { get; set; } = LogFormat.Gelf;
+        public bool IncludeMappedDiagnosticContext { get; set; } = false;
         public bool Async { get; set; } = true;
 
         private bool ReadAsync(IConfiguration configuration)
@@ -26,22 +27,22 @@ namespace Axoom.Extensions.Logging.Console
 
             if (string.IsNullOrEmpty(value))
                 return true;
-                
+
             bool.TryParse(value, out bool async);
             return async;
         }
-        
+
         private LogFormat ReadLogFormat(IConfiguration configuration)
         {
             string value = configuration["Format"];
             if (string.IsNullOrEmpty(value))
                 return LogFormat.Gelf;
-                
+
             if (Enum.TryParse(value, out LogFormat format))
             {
                 return format;
             }
-                
+
             throw new InvalidOperationException($"Configuration \"{value}\" for setting \"{Format}\" is not supported.");
         }
     }

--- a/src/Axoom.Extensions.Logging.Console/Layouts/GelfLayout.cs
+++ b/src/Axoom.Extensions.Logging.Console/Layouts/GelfLayout.cs
@@ -5,8 +5,10 @@ namespace Axoom.Extensions.Logging.Console.Layouts
 {
     internal class GelfLayout : JsonLayout
     {
-        public GelfLayout()
+        public GelfLayout(bool includeMdc = false)
         {
+            this.IncludeMdc = includeMdc;
+
             Attributes.Add(new JsonAttribute("version", "1.1"));
             Attributes.Add(new JsonAttribute("host", Environment.MachineName));
             Attributes.Add(new JsonAttribute("short_message", LayoutFormats.MESSAGE));

--- a/src/Axoom.Extensions.Logging.Console/LogFormatExtensions.cs
+++ b/src/Axoom.Extensions.Logging.Console/LogFormatExtensions.cs
@@ -7,12 +7,15 @@ namespace Axoom.Extensions.Logging.Console
     internal static class LogFormatExtensions
     {
         private static readonly Lazy<GelfLayout> _gelfLayout = new Lazy<GelfLayout>(() => new GelfLayout());
+        private static readonly Lazy<GelfLayout> _gelfLayoutWithContext = new Lazy<GelfLayout>(() => new GelfLayout(true));
         private static readonly Lazy<Layout> _plainLayout = new Lazy<Layout>(() => new PlainLayout());
-        
-        public static Layout GetLayout(this LogFormat format)
+
+        public static Layout GetLayout(this LogFormat format, bool includeMappedDiagnosticContext)
         {
             switch (format)
             {
+                case LogFormat.Gelf when includeMappedDiagnosticContext:
+                    return _gelfLayoutWithContext.Value;
                 case LogFormat.Gelf:
                     return _gelfLayout.Value;
                 case LogFormat.Plain:

--- a/src/Axoom.Extensions.Logging.Console/NlogConfigurationFactory.cs
+++ b/src/Axoom.Extensions.Logging.Console/NlogConfigurationFactory.cs
@@ -14,7 +14,7 @@ namespace Axoom.Extensions.Logging.Console
         {
             var nlogConfig = new LoggingConfiguration();
 
-            Target nlogTarget = CreateConsoleTarget(loggingOptions.Format);
+            Target nlogTarget = CreateConsoleTarget(loggingOptions);
 
             if (loggingOptions.Async)
             {
@@ -26,10 +26,10 @@ namespace Axoom.Extensions.Logging.Console
             return nlogConfig;
         }
 
-        private static ColoredConsoleTarget CreateConsoleTarget(LogFormat format)
+        private static ColoredConsoleTarget CreateConsoleTarget(ConsoleLoggerOptions loggingOptions)
             => new ColoredConsoleTarget(name: TARGET_CONSOLE)
             {
-                Layout = format.GetLayout()
+                Layout = loggingOptions.Format.GetLayout(loggingOptions.IncludeMappedDiagnosticContext)
             };
     }
 }


### PR DESCRIPTION
I'm not quite satisfied with the solution, but it seemed like the most straightforward way to implement custom fields to be added to the gelf output.

What do you think? Do you have better ideas to get custom fields working?

I would appreciate it a lot if we could get this feature soon.